### PR TITLE
[Enhancement] add thread monitor for vCPU thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ bpf_object(kvm_exit src/kvm_exit.bpf.c)
 add_dependencies(kvm_exit_skel libbpf-build)
 add_dependencies(kvm_exit_skel bpftool-build)
 
-add_executable(${PROJECT_NAME} src/main.c src/display.cpp src/kvm_exit.c src/hfi.c src/cpu.c)
+add_executable(${PROJECT_NAME} src/main.c src/display.cpp src/kvm_exit.c src/hfi.c src/cpu.c src/usched.cpp)
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src /usr/include/libnl3)
 target_compile_options(${PROJECT_NAME} PRIVATE -D_GNU_SOURCE -pthread)
 target_link_libraries(${PROJECT_NAME} kvm_exit_skel virt nl-3 nl-genl-3)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -259,7 +259,8 @@ static void kvm_exit_func(struct kvm_exit_info *info)
     update_vcpu_info(info->tgid, info->pid, info->vcpu_id, info->orig_cpu,
                      info->cpu, info->time_ns);
     // add to thread_pool
-    upsert_to_monitor_pool(info->tgid, info->pid,NULL);
+    struct pid_info _pid_info; _pid_info.ppid=0;
+    upsert_to_monitor_pool(info->tgid, info->pid,NULL,_core_map);
 }
 
 static void kvm_exit_loop()

--- a/src/usched.cpp
+++ b/src/usched.cpp
@@ -1,0 +1,236 @@
+/*
+User space qemu process cpu scheduler based on cpu_usage
+*/
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <queue>
+#include <sched.h>
+#include <sstream>
+#include <string>
+#include<linux/sched.h>
+
+#include "usched.hpp"
+#include "cpu.h"
+#include "hfi.h"
+
+#define MAX_HISTORY 10
+#define test 0
+
+namespace fs = std::filesystem;
+
+const static int nprocs = get_nprocs_conf();
+const static int CLK = sysconf(_SC_CLK_TCK);
+
+static std::unordered_map<pid_t, struct pid_info *>
+    pool; //<<pid>,pid_info/tid_info>
+static std::mutex pool_mutex;
+static unsigned long long *cpu_prev_stat;
+static struct core_info *tmp_core_map;
+static unsigned int THREASHOLD = 100;
+
+// insert or update tid
+
+bool upsert_to_monitor_pool(pid_t qemu_id, pid_t tid,
+                            struct pid_info *_pid_info)
+{
+    if (qemu_id == tid)
+        return false;
+    std::lock_guard<std::mutex> lock(pool_mutex);
+    if (qemu_id == tid) {
+        return false;
+    }
+
+    std::string path = "/proc/" + std::to_string(qemu_id) + "/task/" +
+                       std::to_string((tid)) + "/stat";
+    std::ifstream fs(path);
+    std::stringstream buffer;
+    buffer << fs.rdbuf();
+    std::string str;
+    std::vector<std::string> data;
+    int idx = 0, stateidx = -1;
+    std::string state[] = {"R", "S", "D", "Z", "T", "t",
+                           "W", "X", "x", "K", "W", "P"};
+    while (buffer >> str) {
+        data.emplace_back(str);
+        if (stateidx == -1) {
+            for (std::string s : state)
+                if (s.compare(str) == 0)
+                    stateidx = idx;
+        }
+        idx++;
+    }
+    buffer.clear();
+    fs.clear();
+    fs.close();
+
+    if (stateidx == -1) {
+        return false;
+    }
+    // calc process usage
+    int last_cpu, utime, stime;
+    last_cpu = stoi(data[stateidx + TID_STAT_ITEM::PROCESSOR]);
+    utime = stoull(data[stateidx + TID_STAT_ITEM::UTIME]);
+    stime = stoull(data[stateidx + TID_STAT_ITEM::STIME]);
+
+    if (_pid_info == NULL) { // insert
+        struct pid_info *tmp = new struct pid_info(
+            tid, qemu_id, last_cpu,
+            new struct pid_usage_info((double)0, utime, stime));
+        if (tmp) {
+            pool.insert(std::make_pair(tid, tmp));
+            return true;
+        }
+    } else { // update
+        _pid_info->last_cpu = last_cpu;
+        _pid_info->_pid_usage_info->percent =
+            (double)(utime + stime - _pid_info->_pid_usage_info->utime -
+                     _pid_info->_pid_usage_info->stime) *
+            100 /
+            (tmp_core_map[last_cpu]._total -
+             cpu_prev_stat[last_cpu]); // proc_time/per_cpu_time
+
+        _pid_info->_pid_usage_info->utime = utime;
+        _pid_info->_pid_usage_info->stime = stime;
+        return true;
+    }
+    return false;
+}
+
+void removefrom_monitor_pool(pid_t qemu_id, pid_t tid)
+{
+    std::lock_guard<std::mutex> lock(pool_mutex);
+    for (std::unordered_map<pid_t, struct pid_info *>::iterator it =
+             pool.begin();
+         it != pool.end();) {
+        if (it->second->ppid == qemu_id)
+            pool.erase(it);
+        else
+            it++;
+    }
+}
+
+void set_usched_threshold(unsigned int num) { THREASHOLD = num; }
+
+void usched_entry(struct core_info *_core_map)
+{
+    if (_core_map == NULL) {
+        printf("coer_info ptr null!\n");
+        return;
+    }
+    tmp_core_map = _core_map;
+    if (cpu_prev_stat == NULL) {
+        cpu_prev_stat = (decltype(cpu_prev_stat))malloc(
+            sizeof(unsigned long long) * nprocs);
+        for (int i = 0; i < nprocs; i++) {
+            cpu_prev_stat[i] = tmp_core_map[i]._total;
+        }
+        return;
+    }
+
+    for (auto kv : pool) {
+        upsert_to_monitor_pool(kv.second->ppid, kv.second->_thread_id,
+                               kv.second);
+        pid_t tmpid = usched_check(tmp_core_map, kv.second);
+
+        if (tmpid != -1) {
+            if (usched_commit_change(kv.first)) {
+                printf("usched_change succeed!\n");
+            } else
+                printf("usched_change failed!\n");
+
+        } else {
+            if (kv.second->sched == true)
+                if (usched_revert_change(kv.first))
+                    printf("usched_unchanged succeed!\n");
+                else
+                    printf("usched_unchanged failed!\n");
+        }
+    }
+    for (int i = 0; i < nprocs; i++) {
+        cpu_prev_stat[i] = tmp_core_map[i]._total;
+    }
+}
+
+// check if need to sched, return pthread collection
+pid_t usched_check(struct core_info *tmp_core_map, struct pid_info *_pid_info)
+{
+    printf("pid %d : Thread %d  -> Core %d at %.2f%%\n", _pid_info->ppid,
+           _pid_info->_thread_id, _pid_info->last_cpu,
+           _pid_info->_pid_usage_info->percent,
+           _pid_info->_pid_usage_info->utime, tmp_core_map->_total);
+    if ((int)_pid_info->_pid_usage_info->percent >= THREASHOLD &&
+        tmp_core_map[_pid_info->last_cpu].type == INTEL_ATOM) {
+        return _pid_info->_thread_id;
+    }
+    return -1;
+}
+
+// commit change
+bool usched_commit_change(pid_t _thread_id)
+{
+    if (set_affinity_byid(_thread_id, pool.find(_thread_id)->second->last_cpu,
+                          CPUOFF)) {
+        pool.find(_thread_id)->second->sched = true;
+        pool.find(_thread_id)
+            ->second->cpuoff.emplace(pool.find(_thread_id)->second->last_cpu);
+    }
+    return true;
+}
+
+// reverse change
+bool usched_revert_change(pid_t _thread_id)
+{
+
+    while (pool.find(_thread_id)->second->cpuoff.size() > 0)
+        if (set_affinity_byid(_thread_id,
+                              pool.find(_thread_id)->second->cpuoff.front(),
+                              CPUON)) {
+            pool.find(_thread_id)->second->cpuoff.pop();
+        }
+    pool.find(_thread_id)->second->sched = false;
+    return true;
+}
+
+// affinity get & set <bool,cpu_set_t*>
+bool set_affinity_byid(pid_t _thread_id, int cpu_id, enum MASK_DIR md)
+{
+    switch (md) {
+    case CPUON:
+        printf("cpu %d affinity set for %d\n", cpu_id, _thread_id);
+        break;
+    case CPUOFF:
+        printf("cpu %d affinity unset for %d\n", cpu_id, _thread_id);
+        break;
+    default:
+        break;
+    }
+    cpu_set_t *cpumask = CPU_ALLOC(nprocs);
+    sched_getaffinity(_thread_id, sizeof(cpumask), cpumask);
+
+    switch (md) {
+    case CPUON:
+        CPU_SET_S(cpu_id, sizeof(cpumask), cpumask);
+        break;
+    case CPUOFF:
+
+        CPU_CLR_S(cpu_id, sizeof(cpumask), cpumask);
+        break;
+    default:
+        printf("maskdir err\n");
+        return false;
+        break;
+    }
+    if (0 != sched_setaffinity(_thread_id, sizeof(cpumask), cpumask)) {
+        printf("set affinity failed\n");
+        return false;
+    }
+    CPU_FREE(cpumask);
+    return true;
+}

--- a/src/usched.hpp
+++ b/src/usched.hpp
@@ -1,0 +1,125 @@
+#ifndef _USCHED_HPP_
+#define _USCHED_HPP_
+#include <queue>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    CPU_NAME = 0,
+    CPU_USER = 1,
+    CPU_NICE = 2,
+    CPU_SYSTEM = 3,
+    CPU_IDLE = 4,
+    CPU_IOWAIT = 5,
+    CPU_IRRQ = 6,
+    CPU_SOFTIRQ = 7,
+    CPU_STEAL = 8,
+    CPU_GUEST = 9,
+    CPU_GUEST_NICE = 10
+};
+
+enum SCHEDPOLICY { OTHER = 0, FIFO = 1, RR = 2 };
+
+struct pid_usage_info {
+    double percent;
+
+    unsigned long long utime;
+    unsigned long long stime;
+
+    pid_usage_info(double percent, unsigned long long utime,
+                   unsigned long long stime)
+    {
+        this->percent = percent;
+        this->utime = utime;
+        this->stime = stime;
+    }
+};
+struct pid_info {
+    pid_t _thread_id;
+    pid_t ppid;
+    int last_cpu;
+    std::queue<int> cpuoff;
+    bool sched;
+    struct pid_usage_info *_pid_usage_info;
+
+    pid_info(pid_t _thread_id, pid_t ppid, int last_cpu,
+             struct pid_usage_info *pui)
+    {
+        this->ppid = ppid;
+        this->_thread_id = _thread_id;
+        this->last_cpu = last_cpu;
+        this->sched = false;
+        this->_pid_usage_info = pui;
+    }
+
+    ~pid_info() { delete _pid_usage_info; }
+};
+enum MASK_DIR { CPUON, CPUOFF };
+enum TID_STAT_ITEM {
+    STATE = 0,
+    PPID,
+    PGRP,
+    SESSION,
+    TTY_NR,
+    TPGID,
+    FLAGS,
+    MINFLT,
+    CMINFLT,
+    MAJFLT,
+    CMAJFLT,
+    UTIME,
+    STIME,
+    CUTIME,
+    CSTIME,
+    PRIORITY,
+    NICE,
+    NUM_THREADS,
+    ITREALVALUE,
+    STARTTIME,
+    VSIZE,
+    RSS,
+    RSSLIM,
+    STARTCODE,
+    ENDCODE,
+    STARTSTACK,
+    KSTKESP,
+    KSTKEIP,
+    SIGNAL,
+    BLOCKED,
+    SIGIGNORE,
+    SIGCATCH,
+    WCHAN,
+    NSWAP,
+    CNSWAP,
+    EXIT_SIGNAL,
+    PROCESSOR,
+    RT_PRIORITY,
+    POLICY,
+    DELAYACCT_BLKIO_TICKS,
+    GUEST_TIME,
+    CGUST_TIME,
+    START_DATA,
+    END_DATA,
+    START_BRK,
+    ARG_START,
+    ARG_END,
+    ENV_START,
+    ENV_END,
+    EXIT_CODE
+};
+
+extern bool upsert_to_monitor_pool(pid_t qemu_id, pid_t tid,struct pid_info *_pid_info);
+extern void usched_entry(struct core_info *_core_info);
+extern pid_t usched_check(struct core_info *_core_info,
+                          struct pid_info *_pid_info);
+extern bool usched_commit_change(pid_t _thread_id);
+extern bool usched_revert_change(pid_t _thread_id);
+extern bool set_affinity_byid(pid_t _thread_id, int num_cpu, enum MASK_DIR md);
+extern void set_usched_threshold(unsigned int num);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/usched.hpp
+++ b/src/usched.hpp
@@ -27,6 +27,7 @@ struct pid_usage_info {
     unsigned long long utime;
     unsigned long long stime;
 
+    pid_usage_info() {}
     pid_usage_info(double percent, unsigned long long utime,
                    unsigned long long stime)
     {
@@ -41,10 +42,11 @@ struct pid_info {
     int last_cpu;
     std::queue<int> cpuoff;
     bool sched;
-    struct pid_usage_info *_pid_usage_info;
+    struct pid_usage_info _pid_usage_info;
 
+    pid_info() {}
     pid_info(pid_t _thread_id, pid_t ppid, int last_cpu,
-             struct pid_usage_info *pui)
+             struct pid_usage_info pui)
     {
         this->ppid = ppid;
         this->_thread_id = _thread_id;
@@ -53,7 +55,7 @@ struct pid_info {
         this->_pid_usage_info = pui;
     }
 
-    ~pid_info() { delete _pid_usage_info; }
+    ~pid_info() {}
 };
 enum MASK_DIR { CPUON, CPUOFF };
 enum TID_STAT_ITEM {
@@ -109,7 +111,9 @@ enum TID_STAT_ITEM {
     EXIT_CODE
 };
 
-extern bool upsert_to_monitor_pool(pid_t qemu_id, pid_t tid,struct pid_info *_pid_info);
+extern bool upsert_to_monitor_pool(pid_t qemu_id, pid_t tid,
+                                   struct pid_info *_pid_info,
+                                   struct core_info *_core_map);
 extern void usched_entry(struct core_info *_core_info);
 extern pid_t usched_check(struct core_info *_core_info,
                           struct pid_info *_pid_info);
@@ -117,6 +121,7 @@ extern bool usched_commit_change(pid_t _thread_id);
 extern bool usched_revert_change(pid_t _thread_id);
 extern bool set_affinity_byid(pid_t _thread_id, int num_cpu, enum MASK_DIR md);
 extern void set_usched_threshold(unsigned int num);
+extern void remove_from_monitor_pool(pid_t qemu_id, pid_t tid);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. report inside display_loop per second about stats of monitored vCPU threads and change CPU affinity & sched policy when triggered by a constraint that thread shall not run on a E-core with higher than 50% cpu usage.

2. using fn::usched_loop to monitor every thread which has been add to the pool.

3. using fn::addThreadMonitor to pass qemu pid and add all vCPU threads into the pool.

4. mutex lock not implemented.